### PR TITLE
Improve darci

### DIFF
--- a/common/darci.md
+++ b/common/darci.md
@@ -6,19 +6,21 @@ Team charters will have a section on "Responsibilities and Commitments" that lay
 
 These is the set of topics for which the team is the final decision maker on. For some groups, it may be useful to select a subset of consensus builders or deciders, but for most teams it is expected that this will simply be the team as a whole. This can also be on a per-topic basis; for example, a team can record that bikeshed questions are for the team leads to ultimately decide. It is also possible that some questions are escalated to some other team. For example, project groups would often record the parent team as the decision makers, but the project group is still accountable for completing the work to prepare for that decision, and has some amount of "small" decision making.
 
-## Accountable
-This is the set of topics that the team is accountable for completing or executing work in. The most common case of being accountable but not responsible is when a subgroup has been delegated the responsibility for executing.
+## Accountable for results
+This is the set of topics that the team is accountable for work being completed in. The team is thus responsible for ensuring work is happening, but is not necessarily responsible for doing the work themselves. The most common case of being ["accountable for results"](#Accountable-for-results) but not ["responsible for work"](#Responsible-for-work) is when a subgroup has been delegated the responsibility for executing an area of work.
 
 The goal for this section is that this is the group that will be asked and consulted with if the task(s) are not being done in a timely manner. They should also be actively tracking work in any area they are accountable for, so that they can communicate to groups which need to be informed if the task is not done; ideally in time for more resources to be invested or for others to know that the dependency they may need won't be ready.
 
-## Responsible
-This is the set of topics on which the group are the ones engaged in work. This is how, for example, people can discover where to go if they're interested in actively working on some feature or area.
+## Responsible for work
 
-## Consulted
+This is the set of topics on which the group are the ones engaged in the active work. This is how, for example, people can discover where to go if they're interested in actively working on some feature or area.
+
+## Consulted for input
 This is the set of topics on which this group should be consulted. In particular, consultation means that the group may have feedback, but they are not going to make any final decisions.
 
-## Informed
-This is the set of topics on which this group should be informed. This means that the group will not provide feedback on the topic.
+## Informed of change
+
+This is the set of topics on which this group should be informed. This means that the group will not necessarily have to provide feedback on the topic.
 
 The goal for this section is that some teams would benefit from knowing of particular decisions or events, but don't need to engage on the process itself. One example is changes made in rust-lang/rust with sufficient weight that we want to mention them in release notes - the relnotes label is a way to passively inform the release team of this.
 


### PR DESCRIPTION
This is a relatively minor edit, but I did feel like it captures the core issue reasonably well. I didn't actually end up changing the "responsible" and "accountable" words because I couldn't find anything that was easy to refer to in prose, but instead I added qualifiers to them.

Thoughts? @joshtriplett @m-ou-se